### PR TITLE
Add OData options to notes fetching API

### DIFF
--- a/visma-client/lib/Api/NotesV2Api.php
+++ b/visma-client/lib/Api/NotesV2Api.php
@@ -37,6 +37,7 @@ use GuzzleHttp\RequestOptions;
 use Struqtur\VismaEAccounting\ApiException;
 use Struqtur\VismaEAccounting\Configuration;
 use Struqtur\VismaEAccounting\HeaderSelector;
+use Struqtur\VismaEAccounting\Model\ODataQueryOptions;
 use Struqtur\VismaEAccounting\ObjectSerializer;
 
 /**
@@ -97,9 +98,9 @@ class NotesV2Api
      * @throws \InvalidArgumentException
      * @return \Struqtur\VismaEAccounting\Model\NoteApi
      */
-    public function notesV2Get()
+    public function notesV2Get(ODataQueryOptions $odataQueryOptions = null)
     {
-        list($response) = $this->notesV2GetWithHttpInfo();
+        list($response) = $this->notesV2GetWithHttpInfo($odataQueryOptions);
         return $response;
     }
 
@@ -113,10 +114,10 @@ class NotesV2Api
      * @throws \InvalidArgumentException
      * @return array of \Struqtur\VismaEAccounting\Model\NoteApi, HTTP status code, HTTP response headers (array of strings)
      */
-    public function notesV2GetWithHttpInfo()
+    public function notesV2GetWithHttpInfo(ODataQueryOptions $odataQueryOptions = null)
     {
         $returnType = '\Struqtur\VismaEAccounting\Model\NoteApi';
-        $request = $this->notesV2GetRequest();
+        $request = $this->notesV2GetRequest($odataQueryOptions);
 
         try {
             $options = $this->createHttpClientOption();
@@ -254,9 +255,8 @@ class NotesV2Api
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function notesV2GetRequest()
+    protected function notesV2GetRequest(ODataQueryOptions $odataQueryOptions = null)
     {
-
         $resourcePath = '/v2/notes';
         $formParams = [];
         $queryParams = [];
@@ -264,7 +264,16 @@ class NotesV2Api
         $httpBody = '';
         $multipart = false;
 
-
+        if ($odataQueryOptions !== null) {
+            if ($odataQueryOptions->filter) {
+                $queryParams[$odataQueryOptions->filter->param] = $odataQueryOptions->filter->filter;
+            }
+            if ($odataQueryOptions->paging) {
+                foreach ($odataQueryOptions->paging->getParams() as $param => $value) {
+                    $queryParams[$param] = $value;
+                }
+            }
+        }
 
         // body params
         $_tempBody = null;


### PR DESCRIPTION
<!--- TITLE
PR titles should describe the Technical Story.
The Story title and PR title in combination should tell the whole story in the release notes.
The title should be optimized for humans, not machines. 
No ticket numbers, branch names or other machine data in titles - Keep this in the description.
-->
#### Description
<!--- 
Describe the changes in this Pull Request, keep it short and concise.
What existing problem does this solve? 
-->
This PR adds OData options to `NotesV2Api` in order to fetch notes filtered by document id and document type. This is so we can fetch notes that are connected to an invoice draft to be able to transfer them to the invoice.

#### Issue
<!--- 
IMPORTANT: Please do not create a Pull Request without creating an issue first.
Link to related issue, e.g [ch-XXX].
-->
[sc-14083]