### PR TITLE
Add OData options to Unit fetch endpoint

### DIFF
--- a/visma-client/lib/Api/UnitsV2Api.php
+++ b/visma-client/lib/Api/UnitsV2Api.php
@@ -37,6 +37,7 @@ use GuzzleHttp\RequestOptions;
 use Struqtur\VismaEAccounting\ApiException;
 use Struqtur\VismaEAccounting\Configuration;
 use Struqtur\VismaEAccounting\HeaderSelector;
+use Struqtur\VismaEAccounting\Model\ODataQueryOptions;
 use Struqtur\VismaEAccounting\ObjectSerializer;
 
 /**
@@ -97,9 +98,9 @@ class UnitsV2Api
      * @throws \InvalidArgumentException
      * @return \Struqtur\VismaEAccounting\Model\PaginatedResponseUnitApi
      */
-    public function unitsV2Get()
+    public function unitsV2Get(ODataQueryOptions $odataQueryOptions = null)
     {
-        list($response) = $this->unitsV2GetWithHttpInfo();
+        list($response) = $this->unitsV2GetWithHttpInfo($odataQueryOptions);
         return $response;
     }
 
@@ -113,10 +114,10 @@ class UnitsV2Api
      * @throws \InvalidArgumentException
      * @return array of \Struqtur\VismaEAccounting\Model\PaginatedResponseUnitApi, HTTP status code, HTTP response headers (array of strings)
      */
-    public function unitsV2GetWithHttpInfo()
+    public function unitsV2GetWithHttpInfo(ODataQueryOptions $odataQueryOptions = null)
     {
         $returnType = '\Struqtur\VismaEAccounting\Model\PaginatedResponseUnitApi';
-        $request = $this->unitsV2GetRequest();
+        $request = $this->unitsV2GetRequest($odataQueryOptions);
 
         try {
             $options = $this->createHttpClientOption();
@@ -254,9 +255,8 @@ class UnitsV2Api
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function unitsV2GetRequest()
+    protected function unitsV2GetRequest(ODataQueryOptions $odataQueryOptions = null)
     {
-
         $resourcePath = '/v2/units';
         $formParams = [];
         $queryParams = [];
@@ -264,7 +264,16 @@ class UnitsV2Api
         $httpBody = '';
         $multipart = false;
 
-
+        if ($odataQueryOptions !== null) {
+            if ($odataQueryOptions->filter) {
+                $queryParams[$odataQueryOptions->filter->param] = $odataQueryOptions->filter->filter;
+            }
+            if ($odataQueryOptions->paging) {
+                foreach ($odataQueryOptions->paging->getParams() as $param => $value) {
+                    $queryParams[$param] = $value;
+                }
+            }
+        }
 
         // body params
         $_tempBody = null;


### PR DESCRIPTION
<!--- TITLE
PR titles should describe the Technical Story.
The Story title and PR title in combination should tell the whole story in the release notes.
The title should be optimized for humans, not machines. 
No ticket numbers, branch names or other machine data in titles - Keep this in the description.
-->
#### Description
<!--- 
Describe the changes in this Pull Request, keep it short and concise.
What existing problem does this solve? 
-->
This PR adds OData options to the endpoint for fetching units. This is needed in order to fetch all units since the application fails if both the real unit and the default unit are not on the first page.

#### Issue
<!--- 
IMPORTANT: Please do not create a Pull Request without creating an issue first.
Link to related issue, e.g [ch-XXX].
-->
[sc-14567]